### PR TITLE
Stop exit codes from raising errors on Windows

### DIFF
--- a/noid/pynoid.py
+++ b/noid/pynoid.py
@@ -4,6 +4,9 @@ from random import randint
 
 from noid import utils, cli
 
+# make exit codes cross-platform
+SUCCESS_EXIT_CODE = getattr(os, 'EX_OK', 0)
+USAGE_EXIT_CODE = getattr(os, 'EX_USAGE', 64)
 
 def mint(template: str = 'zek', n: int = -1, scheme: str = '', naa: str = '') -> str:
     """ Mint identifiers according to template with a prefix of scheme + naa.
@@ -148,7 +151,7 @@ def main():
     """Main entry point"""
     args = cli.parse_args()
     if args is None:
-        return os.EX_USAGE
+        return USAGE_EXIT_CODE
     if args.validate:
         if args.verbose:
             print(f"info: validating '{args.noid}'...", file=sys.stderr)
@@ -164,7 +167,7 @@ def main():
                   f"scheme={args.scheme}, naa={args.naa}...", file=sys.stderr)
         noid = mint(args.template, args.index, scheme=args.scheme, naa=args.naa)
         print(noid)
-    return os.EX_OK
+    return SUCCESS_EXIT_CODE
 
 
 if __name__ == '__main__':

--- a/test/test.py
+++ b/test/test.py
@@ -179,10 +179,11 @@ class PynoidNoid(unittest.TestCase):
         self.assertRegex(sys.stdout.getvalue(), r"(?ms:^info: generating noid.*template=.*scheme=.*ark[:][/][\w\d]+)")
 
     def test_error(self):
-        """Exit status on *nix is os.EX_USAGE"""
+        """Exit status on *nix is os.EX_USAGE, but its not available on Windows"""
+        USAGE_EXIT_CODE = getattr(os, 'EX_USAGE', 64)
         cli.cli(f"noid -V")
         ex = pynoid.main()
-        self.assertEqual(os.EX_USAGE, ex)
+        self.assertEqual(USAGE_EXIT_CODE, ex)
 
     def test_config(self):
         """Using config"""


### PR DESCRIPTION
`noid` currently raises errors even after successfully minting identifiers on Windows. This is because `os.EX_USAGE` and `os.EX_OK` are not available. This simple fix uses the common exit codes if they are not available.

Thanks for this super helpful project!